### PR TITLE
Use address data from form before local storage

### DIFF
--- a/view/frontend/web/js/view/form/postcode.js
+++ b/view/frontend/web/js/view/form/postcode.js
@@ -30,7 +30,9 @@ define([
         },
 
         getAddressData: function () {
-            if (this.addressType == 'shipping' && typeof checkoutData.getShippingAddressFromData() !== 'undefined' && checkoutData.getShippingAddressFromData()) {
+            if (this.addressType == 'shipping' && this.source && this.source.shippingAddress && this.source.shippingAddress.country_id !== '') {
+                return this.source.shippingAddress;
+            } else if (this.addressType == 'shipping' && typeof checkoutData.getShippingAddressFromData() !== 'undefined' && checkoutData.getShippingAddressFromData()) {
                 return checkoutData.getShippingAddressFromData();
             } else if (this.addressType == 'billing' && typeof checkoutData.getBillingAddressFromData() !== 'undefined' && checkoutData.getBillingAddressFromData()) {
                 return checkoutData.getBillingAddressFromData();


### PR DESCRIPTION
Use address data from form before using the local storage data.
This prevents the fields on your form not showing/hiding when country is changed while other address fields are empty.